### PR TITLE
Unable to open notebook on GitHub - added link to notebook on nbviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Sequential Sampling Modeling in HSSM
+
+[![Render Notebook](https://img.shields.io/badge/render-nbviewer-orange?logo=jupyter)](https://nbviewer.org/github/gingjehli/HSSM/blob/main/HSSMtutorial_ExtBasic_v1.ipynb)
+
+This is a tutorial offering a comprehensive setup for HSSM (Hierarchical Sequential Sampling Models). Please click the button above to open the notebook.


### PR DESCRIPTION
Hi, I was unable to open the notebook directly from GitHub, so I created a very basic README with a link to the notebook on nbviewer which will navigate past this issue.

![CleanShot 2024-05-19 at 15 15 06@2x](https://github.com/gingjehli/HSSM/assets/35841800/41ac1346-e201-4a49-8a74-884437cb01a2)
